### PR TITLE
ポート番号を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 8080",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
バックエンドとポート番号が重なっていたため、開発用サーバーのポート番号を3000番から8080番に変更。